### PR TITLE
Updated `dbt-*` package versions.

### DIFF
--- a/dbt-docker/docker/dbt/requirements.txt
+++ b/dbt-docker/docker/dbt/requirements.txt
@@ -1,6 +1,6 @@
-dbt-core==1.0.1
-dbt-postgres==1.0.1
-dbt-redshift==1.0.0
-dbt-snowflake==1.0.0
-dbt-bigquery==1.0.0
-dbt-materialize==1.0.1
+dbt-core==1.6.6
+dbt-postgres==1.6.6
+dbt-redshift==1.6.2
+dbt-snowflake==1.6.4
+dbt-bigquery==1.6.7
+dbt-materialize==1.6.0


### PR DESCRIPTION
Reason: the version in the image is currently affected by [this bug](https://github.com/dbt-labs/dbt-core/issues/4745) upon any `dbt` command.